### PR TITLE
Link Browser Use Box runtime demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It provides a [pydantic](https://docs.pydantic.dev/latest/)-based API for implem
 
 ♾️ It's inspired by the simplicity of async and events in `JS`, we aim to bring a fully type-checked [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)-style API to Python.
 
+Used in Browser Use: Bubus is one of the async coordination primitives behind long-running Browser Use agents. To run Browser Use automation continuously from your own machine, see [Browser Use Box](https://browser-use.com/bux) and [watch the 15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 <br/>
 
 ## 🔢 Quickstart


### PR DESCRIPTION
## Summary
- add a README link from Bubus to Browser Use Box as a long-running Browser Use runtime
- link the public 15-second TikTok demo

## Test
- git diff --check
- README link assertion


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add README links to Browser Use Box for running long‑lived Browser Use agents from your machine, and to a 15‑second TikTok demo. This clarifies how Bubus is used as an async coordination primitive in these agents.

<sup>Written for commit 7f22d99774ffce5ac726d2da84e25df0b4ee0b5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

