### PR TITLE
Revert "Link Browser Use Box runtime demo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ It provides a [pydantic](https://docs.pydantic.dev/latest/)-based API for implem
 
 ♾️ It's inspired by the simplicity of async and events in `JS`, we aim to bring a fully type-checked [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)-style API to Python.
 
-Used in Browser Use: Bubus is one of the async coordination primitives behind long-running Browser Use agents. To run Browser Use automation continuously from your own machine, see [Browser Use Box](https://browser-use.com/bux) and [watch the 15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 <br/>
 
 ## 🔢 Quickstart


### PR DESCRIPTION
Reverts browser-use/bubus#27

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove Browser Use Box runtime demo links from the README by reverting the prior change. Keeps docs focused on the library and removes external promo links.

<sup>Written for commit 9a40e236890750c8ee2ae283ad01c865f9cbc239. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

