### PR TITLE
fix: correct EventBus capacity accounting

### DIFF
--- a/bubus/service.py
+++ b/bubus/service.py
@@ -542,17 +542,20 @@ class EventBus:
             f'Event.event_path must be a list of valid EventBus names, got: {event.event_path}'
         )
 
-        # Check hard limit on total pending events (queue + in-progress)
+        # Check queue and hard limits on total pending events (queue + in-progress)
         # Only enforce if we have memory limits set
         if self.max_history_size is not None:
             queue_size = self.event_queue.qsize() if self.event_queue else 0
-            pending_in_history = sum(1 for e in self.event_history.values() if e.event_status in ('pending', 'started'))
-            total_pending = queue_size + pending_in_history
+            # Queued events are also stored in history as pending, so only started events are non-overlapping.
+            processing_count = sum(1 for event in self.event_history.values() if event.event_status == 'started')
+            total_pending = queue_size + processing_count
+            queue_is_full = self.event_queue.full() if self.event_queue else False
 
-            if total_pending >= 100:
+            if total_pending >= 100 or queue_is_full:
+                capacity_reason = '100 max' if total_pending >= 100 else 'queue full'
                 raise RuntimeError(
-                    f'EventBus at capacity: {total_pending} pending events (100 max). '
-                    f'Queue: {queue_size}, Processing: {pending_in_history}. '
+                    f'EventBus at capacity: {total_pending} pending events ({capacity_reason}). '
+                    f'Queue: {queue_size}, Processing: {processing_count}. '
                     f'Cannot accept new events until some complete.'
                 )
 

--- a/tests/test_stress_20k_events.py
+++ b/tests/test_stress_20k_events.py
@@ -156,41 +156,30 @@ async def test_20k_events_with_memory_control():
 
 
 @pytest.mark.asyncio
-async def test_hard_limit_enforcement():
-    """Test that hard limit of 100 pending events is enforced"""
-    bus = EventBus(name='HardLimitTest')
+async def test_capacity_does_not_double_count_queued_events():
+    """Queued events should not also be reported as processing."""
+    bus = EventBus(name='CapacityAccountingTest')
 
     try:
-        # Create a slow handler to keep events pending
-        async def slow_handler(event: SimpleEvent) -> None:
-            await asyncio.sleep(0.5)  # Reduced from 10s to 0.5s
+        for _ in range(50):
+            bus.dispatch(SimpleEvent())
 
-        bus.on('SimpleEvent', slow_handler)
+        assert bus.event_queue is not None
+        assert bus.event_queue.qsize() == 50
+        assert len(bus.events_pending) == 50
+        assert len(bus.events_started) == 0
 
-        # Try to dispatch more than 100 events
-        events_dispatched = 0
-        errors = 0
+        with pytest.raises(RuntimeError) as exc_info:
+            bus.dispatch(SimpleEvent())
 
-        for _ in range(150):
-            try:
-                bus.dispatch(SimpleEvent())
-                events_dispatched += 1
-            except RuntimeError as e:
-                if 'EventBus at capacity' in str(e):
-                    errors += 1
-                else:
-                    raise
-
-        print(f'\nDispatched {events_dispatched} events')
-        print(f'Hit capacity error {errors} times')
-
-        # Should hit the limit
-        assert events_dispatched <= 100
-        assert errors > 0
+        error_message = str(exc_info.value)
+        assert 'EventBus at capacity: 50 pending events (queue full).' in error_message
+        assert 'Queue: 50, Processing: 0.' in error_message
+        assert '100 pending' not in error_message
+        assert 'Processing: 50' not in error_message
 
     finally:
-        # Properly stop the bus to clean up pending tasks
-        await bus.stop(timeout=0, clear=True)  # Don't wait, just force cleanup
+        await bus.stop(timeout=0, clear=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- count queued and processing events as non-overlapping capacity inputs
- report queue saturation with accurate queue and processing counts
- replace the misleading capacity regression with a focused 50-event queue test

## Tests
- uv run pytest -q tests/
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EventBus capacity checks by separating queued from processing events and enforcing a queue‑full condition to prevent premature capacity errors.

- **Bug Fixes**
  - Compute pending as queue size + started events only; stop double counting queued items in history.
  - Raise capacity errors with a clear reason ('100 max' or 'queue full') and report separate Queue and Processing counts.
  - Replace the 100-limit stress test with a focused 50-event queue saturation test that validates accurate counts and messaging.

<sup>Written for commit 3ab4c41d9b04c988db1a1ee91c08d12682c480c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/bubus/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

